### PR TITLE
Clean unused payment fields

### DIFF
--- a/User-Achat/generate_bon_commande.php
+++ b/User-Achat/generate_bon_commande.php
@@ -187,9 +187,9 @@ try {
             // Récupérer le mode de paiement depuis la première commande trouvée
             $firstMaterialId = array_keys($materialPrices)[0];
 
-            $paymentQuery = "SELECT am.mode_paiement_id, pm.label as payment_label, pm.description, pm.icon
-                FROM achats_materiaux am 
-                LEFT JOIN payment_methods pm ON am.mode_paiement_id = pm.id 
+            $paymentQuery = "SELECT am.mode_paiement_id, pm.label as payment_label
+                FROM achats_materiaux am
+                LEFT JOIN payment_methods pm ON am.mode_paiement_id = pm.id
                 WHERE am.id = ? OR am.expression_id = ?
                 ORDER BY am.date_achat DESC LIMIT 1";
 
@@ -202,10 +202,6 @@ try {
             if ($paymentInfo) {
                 $paymentMethod = $paymentInfo['mode_paiement_id'] ?? '';
                 $paymentMethodLabel = $paymentInfo['payment_label'] ?? 'Non spécifié';
-
-                // NOUVEAU : Informations supplémentaires disponibles
-                $paymentMethodDescription = $paymentInfo['description'] ?? '';
-                $paymentMethodIcon = $paymentInfo['icon'] ?? '';
             }
         } catch (Exception $e) {
             error_log("Erreur lors de la récupération du mode de paiement: " . $e->getMessage());


### PR DESCRIPTION
## Summary
- drop unused payment method description and icon from generate_bon_commande

## Testing
- `php -l User-Achat/generate_bon_commande.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ebff803c832da6f830b2e08dce86