### PR TITLE
Fix purchase order button visibility

### DIFF
--- a/User-Achat/achats_materiaux.php
+++ b/User-Achat/achats_materiaux.php
@@ -1971,37 +1971,32 @@ function formatNumber($number)
                                         /* Informations bon de commande */
                                         (SELECT po.id 
                                          FROM purchase_orders po 
-                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id 
+                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id
                                                 OR JSON_CONTAINS(po.related_expressions, CONCAT('\"', main_data.expression_id, '\"')))
-                                         AND BINARY po.fournisseur = BINARY main_data.fournisseur
                                          ORDER BY po.generated_at DESC LIMIT 1) as bon_commande_id,
                                                                 
                                         (SELECT po.order_number 
                                          FROM purchase_orders po 
-                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id 
+                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id
                                                 OR JSON_CONTAINS(po.related_expressions, CONCAT('\"', main_data.expression_id, '\"')))
-                                         AND BINARY po.fournisseur = BINARY main_data.fournisseur
                                          ORDER BY po.generated_at DESC LIMIT 1) as bon_commande_number,
                                                                 
                                         (SELECT po.signature_finance 
                                          FROM purchase_orders po 
                                          WHERE (BINARY po.expression_id = BINARY main_data.expression_id 
                                                 OR JSON_CONTAINS(po.related_expressions, CONCAT('\"', main_data.expression_id, '\"')))
-                                         AND BINARY po.fournisseur = BINARY main_data.fournisseur
                                          ORDER BY po.generated_at DESC LIMIT 1) as signature_finance,
                                                                 
                                         (SELECT po.user_finance_id 
                                          FROM purchase_orders po 
-                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id 
+                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id
                                                 OR JSON_CONTAINS(po.related_expressions, CONCAT('\"', main_data.expression_id, '\"')))
-                                         AND BINARY po.fournisseur = BINARY main_data.fournisseur
                                          ORDER BY po.generated_at DESC LIMIT 1) as user_finance_id,
                                                                 
                                         (SELECT po.file_path 
                                          FROM purchase_orders po 
-                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id 
+                                         WHERE (BINARY po.expression_id = BINARY main_data.expression_id
                                                 OR JSON_CONTAINS(po.related_expressions, CONCAT('\"', main_data.expression_id, '\"')))
-                                         AND BINARY po.fournisseur = BINARY main_data.fournisseur
                                          ORDER BY po.generated_at DESC LIMIT 1) as bon_commande_path
                                                                 
                                     FROM (


### PR DESCRIPTION
## Summary
- fix query retrieving purchase order info so it no longer filters by supplier

## Testing
- `php -l User-Achat/achats_materiaux.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686391230648832d89daf29bbbed467b