### PR TITLE
Fix modal closing after proforma upload

### DIFF
--- a/User-Achat/assets/js/proforma_upload.js
+++ b/User-Achat/assets/js/proforma_upload.js
@@ -285,9 +285,10 @@ const ProformaUploadManager = {
     showError(message) {
         if (window.Swal) {
             Swal.fire({
-                title: 'Erreur de fichier',
                 text: message,
                 icon: 'error',
+                toast: true,
+                position: 'top-end',
                 timer: 5000,
                 showConfirmButton: false
             });
@@ -302,9 +303,10 @@ const ProformaUploadManager = {
     showSuccess(message) {
         if (window.Swal) {
             Swal.fire({
-                title: 'Succès',
                 text: message,
                 icon: 'success',
+                toast: true,
+                position: 'top-end',
                 timer: 3000,
                 showConfirmButton: false
             });
@@ -317,9 +319,10 @@ const ProformaUploadManager = {
     showInfo(message) {
         if (window.Swal) {
             Swal.fire({
-                title: 'Information',
                 text: message,
                 icon: 'info',
+                toast: true,
+                position: 'top-end',
                 timer: 3000,
                 showConfirmButton: false
             });


### PR DESCRIPTION
## Summary
- prevent the order completion modal from closing when a pro-forma file is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863b8dfd5b0832dbcfbb7c84c6765ea