### PR TITLE
Fix payment mode retrieval

### DIFF
--- a/User-Achat/api/orders/edit_order.php
+++ b/User-Achat/api/orders/edit_order.php
@@ -94,7 +94,7 @@ try {
         ':new_price' => $prixUnitaire,
         ':old_supplier' => $currentData['fournisseur'],
         ':new_supplier' => $fournisseur,
-        ':old_payment_method' => $currentData['mode_paiement'] ?? null,
+        ':old_payment_method' => $currentData['mode_paiement_id'] ?? null,
         ':new_payment_method' => $paymentMethod,
         ':modification_reason' => $notes,
         ':modified_by' => $userId
@@ -105,7 +105,7 @@ try {
                         SET quantity = :quantity, 
                             prix_unitaire = :prix_unitaire, 
                             fournisseur = :fournisseur,
-                            mode_paiement = :payment_method,
+                            mode_paiement_id = :payment_method,
                             notes = :notes,
                             updated_at = NOW()
                         WHERE id = :order_id";

--- a/User-Achat/gestion-bon-commande/api/download_validated_bon_commande.php
+++ b/User-Achat/gestion-bon-commande/api/download_validated_bon_commande.php
@@ -48,14 +48,14 @@ try {
     // 2. NOUVEAU : Récupérer le mode de paiement depuis achats_materiaux
     $paymentMode = 'Non spécifié'; // Valeur par défaut
     
-    // Récupérer le mode de paiement depuis les achats liés à ce bon de commande
-    $paymentQuery = "SELECT DISTINCT am.mode_paiement 
-                     FROM achats_materiaux am 
-                     WHERE am.expression_id = ? 
-                     AND am.fournisseur = ? 
+    // Récupérer le libellé du mode de paiement depuis les achats liés à ce bon de commande
+    $paymentQuery = "SELECT DISTINCT pm.label
+                     FROM achats_materiaux am
+                     JOIN payment_methods pm ON am.mode_paiement_id = pm.id
+                     WHERE am.expression_id = ?
+                     AND am.fournisseur = ?
                      AND DATE(am.date_achat) = DATE(?)
-                     AND am.mode_paiement IS NOT NULL 
-                     AND am.mode_paiement != ''
+                     AND am.mode_paiement_id IS NOT NULL
                      LIMIT 1";
     
     $paymentStmt = $pdo->prepare($paymentQuery);
@@ -69,12 +69,12 @@ try {
         $relatedExpressions = json_decode($order['related_expressions'], true);
         if ($relatedExpressions && is_array($relatedExpressions)) {
             $placeholders = implode(',', array_fill(0, count($relatedExpressions), '?'));
-            $altPaymentQuery = "SELECT DISTINCT am.mode_paiement 
-                               FROM achats_materiaux am 
-                               WHERE am.expression_id IN ($placeholders) 
-                               AND am.fournisseur = ? 
-                               AND am.mode_paiement IS NOT NULL 
-                               AND am.mode_paiement != ''
+            $altPaymentQuery = "SELECT DISTINCT pm.label
+                               FROM achats_materiaux am
+                               JOIN payment_methods pm ON am.mode_paiement_id = pm.id
+                               WHERE am.expression_id IN ($placeholders)
+                               AND am.fournisseur = ?
+                               AND am.mode_paiement_id IS NOT NULL
                                LIMIT 1";
             
             $params = $relatedExpressions;


### PR DESCRIPTION
## Summary
- join `payment_methods` to fetch payment labels in validated order download API
- update order editing logic to use `mode_paiement_id`

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_6863c59ddd5c832d947cda5bfe9fe349