### PR TITLE
Fix payment label fallback in bon de commande

### DIFF
--- a/User-Achat/generate_bon_commande.php
+++ b/User-Achat/generate_bon_commande.php
@@ -213,7 +213,7 @@ try {
 
     // Valeur par défaut si aucun mode de paiement trouvé
     if (empty($paymentMethodLabel)) {
-        $paymentMethodLabel = $paymentMethod ?: 'Non spécifié';
+        $paymentMethodLabel = 'Non spécifié';
     }
 
     // Construire la requête pour récupérer les matériaux en fonction de la sélection


### PR DESCRIPTION
## Summary
- ensure bon de commande displays the payment method label when missing

## Testing
- `php -l User-Achat/generate_bon_commande.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f49c69f4832dba7adcb391563b3e