### PR TITLE
Fix partial order completion issues

### DIFF
--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -2789,7 +2789,7 @@ const PartialOrdersManager = {
             if (result.isConfirmed && result.value) {
                 // Gestion du succès avec détails
                 const paymentInfo = PaymentMethodsManager.getMethodById(
-                    document.getElementById('payment-method')?.value
+                    result.value.payment_method
                 );
                 Swal.fire({
                     title: 'Succès !',


### PR DESCRIPTION
## Summary
- show selected payment method after completing a partial order
- track expression ids when completing multiple partial orders
- set session variables for PDF download token correctly

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686410df69d4832da8684408544fe8ff