### PR TITLE
Fix proforma upload for partial orders

### DIFF
--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -2892,8 +2892,16 @@ const PartialOrdersManager = {
             formData.append('payment_method', paymentMethod); // NOUVEAU : obligatoire
             formData.append('source_table', sourceTable);
             const proformaInput = document.getElementById('proforma-upload');
+            let proformaFile = null;
             if (proformaInput && proformaInput.files.length > 0) {
-                formData.append('proforma_file', proformaInput.files[0]);
+                proformaFile = proformaInput.files[0];
+            } else if (window.ProformaUploadManager &&
+                typeof ProformaUploadManager.hasFile === 'function' &&
+                ProformaUploadManager.hasFile()) {
+                proformaFile = ProformaUploadManager.getFile();
+            }
+            if (proformaFile) {
+                formData.append('proforma_file', proformaFile);
             }
             if (fournisseurResult.newFournisseur) {
                 formData.append('create_fournisseur', '1');

--- a/User-Achat/commandes-traitement/api.php
+++ b/User-Achat/commandes-traitement/api.php
@@ -402,7 +402,7 @@ function handleCompletePartialOrder($pdo, $user_id)
     // Gestion du pro-forma
     require_once 'upload_proforma.php';
     $proformaHandler = new ProformaUploadHandler($pdo);
-    $hasProforma = isset($_FILES['proforma_file']) && $_FILES['proforma_file']['error'] !== UPLOAD_ERR_NO_FILE;
+    $hasProforma = isset($_FILES['proforma_file']) && $_FILES['proforma_file']['error'] === UPLOAD_ERR_OK;
 
     // Validation des données - MODIFIÉE
     if (!$materialId || $quantiteCommande <= 0 || !$fournisseur || $prixUnitaire <= 0 || !$paymentMethod) {
@@ -850,7 +850,7 @@ function completeMultiplePartial($pdo, $user_id)
         // NOUVEAU : Initialiser le gestionnaire de pro-forma
         $proformaHandler = new ProformaUploadHandler($pdo);
         $proformaResults = [];
-        $hasProforma = isset($_FILES['proforma_file']) && $_FILES['proforma_file']['error'] !== UPLOAD_ERR_NO_FILE;
+        $hasProforma = isset($_FILES['proforma_file']) && $_FILES['proforma_file']['error'] === UPLOAD_ERR_OK;
 
         // Validation du mode de paiement
         $paymentData = validatePaymentMethod($pdo, $paymentMethod);

--- a/User-Achat/commandes-traitement/besoins/complete_besoin_partial.php
+++ b/User-Achat/commandes-traitement/besoins/complete_besoin_partial.php
@@ -21,7 +21,7 @@ if (file_exists('../utils/system_logger.php')) {
 // Gestion du pro-forma
 require_once '../upload_proforma.php';
 $proformaHandler = new ProformaUploadHandler($pdo);
-$hasProforma = isset($_FILES['proforma_file']) && $_FILES['proforma_file']['error'] !== UPLOAD_ERR_NO_FILE;
+$hasProforma = isset($_FILES['proforma_file']) && $_FILES['proforma_file']['error'] === UPLOAD_ERR_OK;
 
 // Récupérer les données du formulaire
 $materialId = isset($_POST['material_id']) ? $_POST['material_id'] : null;


### PR DESCRIPTION
## Summary
- ensure partial order form sends selected proforma file even when DOM changes
- verify uploaded file validity before saving in `complete_besoin_partial.php`
- same check for generic partial order API

## Testing
- `php -l User-Achat/commandes-traitement/besoins/complete_besoin_partial.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865132a0fe0832da978623bbba04b28