### PR TITLE
Fix pro‑forma upload

### DIFF
--- a/User-Achat/commandes-traitement/upload_proforma.php
+++ b/User-Achat/commandes-traitement/upload_proforma.php
@@ -50,6 +50,8 @@ class ProformaUploadHandler
             'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
             'application/vnd.ms-excel',
             'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            // Certains navigateurs envoient les PDF sous ce type MIME générique
+            'application/octet-stream',
             'image/jpeg',
             'image/jpg',
             'image/png',


### PR DESCRIPTION
## Summary
- broaden MIME type acceptance for pro-forma uploads so files reported as `application/octet-stream` are processed

## Testing
- `php -l User-Achat/commandes-traitement/upload_proforma.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686520e71fa8832d81e2d367117a0822