### PR TITLE
Fix bulk completion missing form fields

### DIFF
--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -1943,6 +1943,19 @@ const PurchaseManager = {
             });
             // Préparer les données
             const formData = new FormData(form);
+            // Assurer la présence des champs essentiels
+            if (!formData.has('fournisseur')) {
+                formData.append('fournisseur', fournisseur);
+            } else {
+                formData.set('fournisseur', fournisseur);
+            }
+            const paymentMethodValue = document.getElementById('payment-method-bulk').value;
+            if (!formData.has('payment_method')) {
+                formData.append('payment_method', paymentMethodValue);
+            } else {
+                formData.set('payment_method', paymentMethodValue);
+            }
+
             if (!formData.has('bulk_purchase')) {
                 formData.append('bulk_purchase', '1');
             }


### PR DESCRIPTION
## Summary
- ensure supplier and payment method fields are always included when submitting the bulk completion modal

## Testing
- `node --check User-Achat/assets/js/achats-materiaux.js`

------
https://chatgpt.com/codex/tasks/task_e_686557d43a80832d8633072354d8f746