### PR TITLE
Fix purchase order link for bulk purchases

### DIFF
--- a/User-Achat/process_bulk_purchase.php
+++ b/User-Achat/process_bulk_purchase.php
@@ -454,6 +454,17 @@ try {
 
                 // Mise à jour des prix produits
                 updateProductPrice($pdo, $material['designation'], $price);
+                // Stocker les informations de commande pour le bon de commande
+                if (!isset($_SESSION['bulk_purchase_orders'])) {
+                    $_SESSION['bulk_purchase_orders'] = [];
+                }
+                $_SESSION['bulk_purchase_orders'][] = [
+                    "material_id" => $materialId,
+                    "order_id" => $newOrderId,
+                    "quantity" => $quantity,
+                    "remaining" => $remainingQuantity,
+                    "is_complete" => !$isPartialOrder
+                ];
             }
         } else if ($tableSource === 'besoins') {
             // ========================================
@@ -586,6 +597,17 @@ try {
 
                 // Mise à jour des prix produits
                 updateProductPrice($pdo, $material['designation_article'], $price);
+                // Stocker les informations de commande pour le bon de commande
+                if (!isset($_SESSION['bulk_purchase_orders'])) {
+                    $_SESSION['bulk_purchase_orders'] = [];
+                }
+                $_SESSION['bulk_purchase_orders'][] = [
+                    "material_id" => $materialId,
+                    "order_id" => $newOrderId,
+                    "quantity" => $quantity,
+                    "remaining" => $remainingQuantity,
+                    "is_complete" => !$isPartialOrder
+                ];
             }
         }
     }


### PR DESCRIPTION
## Summary
- store bulk purchase order ids in session when placing grouped orders

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665c0a8afc832d9e426f5ab6f70af4