### PR TITLE
Fix project code not saved with proforma

### DIFF
--- a/User-Achat/commandes-traitement/api.php
+++ b/User-Achat/commandes-traitement/api.php
@@ -459,7 +459,7 @@ function handleCompletePartialOrder($pdo, $user_id)
         }
 
         // 1. Récupérer les informations du matériau
-        $materialQuery = "SELECT ed.*, ip.nom_client
+        $materialQuery = "SELECT ed.*, ip.code_projet, ip.nom_client
                            FROM expression_dym ed
                            LEFT JOIN identification_projet ip ON ed.idExpression = ip.idExpression
                            WHERE ed.id = :id";


### PR DESCRIPTION
## Summary
- ensure `handleCompletePartialOrder` fetches `code_projet` when uploading proformas so the `projet_client` field is populated correctly

## Testing
- `php -l User-Achat/commandes-traitement/api.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866aacb3f74832dab60d93370b3d633