### PR TITLE
Add product reference to proformas

### DIFF
--- a/User-Achat/commandes-traitement/api.php
+++ b/User-Achat/commandes-traitement/api.php
@@ -627,7 +627,8 @@ function handleCompletePartialOrder($pdo, $user_id)
                     $_FILES['proforma_file'],
                     $newOrderId,
                     $fournisseurId,
-                    $material['code_projet'] ?? null
+                    $material['code_projet'] ?? null,
+                    $material['product_id'] ?? null
                 );
                 $proformaUploaded = $upload['success'];
                 if ($proformaUploaded && isset($upload['proforma_id'])) {
@@ -975,7 +976,8 @@ function completeMultiplePartial($pdo, $user_id)
                                 $_FILES['proforma_file'],
                                 $result['order_id'],
                                 $fournisseurId,
-                                $result['project_client'] ?? null
+                                $result['project_client'] ?? null,
+                                $result['product_id'] ?? null
                             );
 
                             $proformaResults[] = [

--- a/User-Achat/commandes-traitement/besoins/complete_besoin_partial.php
+++ b/User-Achat/commandes-traitement/besoins/complete_besoin_partial.php
@@ -270,7 +270,8 @@ try {
                 $_FILES['proforma_file'],
                 $newOrderId,
                 $fournisseurId,
-                $besoin['idBesoin'] ?? null
+                $besoin['idBesoin'] ?? null,
+                $besoin['product_id'] ?? null
             );
             $proformaUploaded = $upload['success'];
             if ($proformaUploaded && isset($upload['proforma_id'])) {

--- a/User-Achat/commandes-traitement/sql/proformas.sql
+++ b/User-Achat/commandes-traitement/sql/proformas.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS `proformas` (
   `achat_materiau_id` int(11) NOT NULL COMMENT 'ID de la commande dans achats_materiaux',
   `bon_commande_id` int(11) DEFAULT NULL COMMENT 'ID du bon de commande (si table séparée)',
   `fournisseur_id` int(11) NOT NULL COMMENT 'ID du fournisseur',
+  `id_product` int(11) DEFAULT NULL COMMENT 'ID du produit concerné',
   `projet_client` varchar(255) DEFAULT NULL COMMENT 'Projet ou client associé',
   `file_path` varchar(500) NOT NULL COMMENT 'Chemin vers le fichier pro-forma',
   `original_filename` varchar(255) NOT NULL COMMENT 'Nom original du fichier',
@@ -25,6 +26,7 @@ CREATE TABLE IF NOT EXISTS `proformas` (
   KEY `idx_upload_date` (`upload_date`),
   KEY `idx_status` (`status`),
   KEY `idx_upload_user` (`upload_user_id`),
+  KEY `idx_product` (`id_product`),
   -- Contrainte pour lier aux achats de matériaux
   CONSTRAINT `fk_proforma_achat` FOREIGN KEY (`achat_materiau_id`) 
     REFERENCES `achats_materiaux` (`id`) ON DELETE CASCADE ON UPDATE CASCADE

--- a/User-Achat/commandes-traitement/upload_proforma.php
+++ b/User-Achat/commandes-traitement/upload_proforma.php
@@ -65,7 +65,7 @@ class ProformaUploadHandler
     /**
      * Upload un fichier pro-forma et l'associe à une commande
      */
-    public function uploadFile($fileData, $achatMateriauxId, $fournisseurId, $projetClient = null)
+    public function uploadFile($fileData, $achatMateriauxId, $fournisseurId, $projetClient = null, $productId = null)
     {
         try {
             // Validation de base
@@ -94,7 +94,8 @@ class ProformaUploadHandler
                 $fournisseurId,
                 $projetClient,
                 $filename,
-                $fileData
+                $fileData,
+                $productId
             );
 
             // Log de succès
@@ -204,19 +205,20 @@ class ProformaUploadHandler
     /**
      * Sauvegarde les informations en base de données
      */
-    private function saveToDatabase($achatMateriauxId, $fournisseurId, $projetClient, $filename, $fileData)
+    private function saveToDatabase($achatMateriauxId, $fournisseurId, $projetClient, $filename, $fileData, $productId = null)
     {
         $query = "INSERT INTO proformas (
             achat_materiau_id,
             fournisseur_id,
+            id_product,
             projet_client,
             file_path,
             original_filename,
-            file_type, 
-            file_size, 
+            file_type,
+            file_size,
             upload_user_id, 
             status
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'en_attente')";
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'en_attente')";
 
         $stmt = $this->pdo->prepare($query);
 
@@ -226,6 +228,7 @@ class ProformaUploadHandler
         $stmt->execute([
             $achatMateriauxId,
             $fournisseurId,
+            $productId,
             $projetClient,
             $filePath,
             $fileData['name'],

--- a/User-Achat/process_bulk_purchase.php
+++ b/User-Achat/process_bulk_purchase.php
@@ -156,7 +156,7 @@ if (empty($materialIds) || empty($fournisseur) || empty($paymentMethod)) {
 /**
  * Fonction pour traiter l'upload du pro-forma après création de commande
  */
-function processProformaUpload($pdo, $achatMateriauxId, $fournisseurId, $projetClient = null)
+function processProformaUpload($pdo, $achatMateriauxId, $fournisseurId, $projetClient = null, $productId = null)
 {
     // Vérifier qu'un fichier pro-forma a été uploadé
     if (!isset($_FILES['proforma_file']) || $_FILES['proforma_file']['error'] === UPLOAD_ERR_NO_FILE) {
@@ -170,7 +170,8 @@ function processProformaUpload($pdo, $achatMateriauxId, $fournisseurId, $projetC
             $_FILES['proforma_file'],
             $achatMateriauxId,
             $fournisseurId,
-            $projetClient
+            $projetClient,
+            $productId
         );
 
         return $result;
@@ -381,7 +382,7 @@ try {
                 $newOrderId = $pdo->lastInsertId();
 
                 // NOUVEAU : Traiter l'upload du pro-forma
-                $proformaResult = processProformaUpload($pdo, $newOrderId, $fournisseurId, $material['idExpression']);
+                $proformaResult = processProformaUpload($pdo, $newOrderId, $fournisseurId, $material['idExpression'], $material['product_id'] ?? null);
                 if ($proformaResult) {
                     if ($proformaResult['success']) {
                         $proformasUploaded++;
@@ -529,7 +530,7 @@ try {
                 $newOrderId = $pdo->lastInsertId();
 
                 // NOUVEAU : Traiter l'upload du pro-forma
-                $proformaResult = processProformaUpload($pdo, $newOrderId, $fournisseurId, $material['idBesoin']);
+                $proformaResult = processProformaUpload($pdo, $newOrderId, $fournisseurId, $material['idBesoin'], $material['product_id'] ?? null);
                 if ($proformaResult) {
                     if ($proformaResult['success']) {
                         $proformasUploaded++;

--- a/classes/tables.sql
+++ b/classes/tables.sql
@@ -201,6 +201,7 @@ CREATE TABLE IF NOT EXISTS `proformas` (
   `achat_materiau_id` int(11) NOT NULL COMMENT 'ID de la commande dans achats_materiaux',
   `bon_commande_id` int(11) DEFAULT NULL COMMENT 'ID du bon de commande (si table séparée)',
   `fournisseur_id` int(11) NOT NULL COMMENT 'ID du fournisseur',
+  `id_product` int(11) DEFAULT NULL COMMENT 'ID du produit concerné',
   `projet_client` varchar(255) DEFAULT NULL COMMENT 'Projet ou client associé',
   `file_path` varchar(500) NOT NULL COMMENT 'Chemin vers le fichier pro-forma',
   `original_filename` varchar(255) NOT NULL COMMENT 'Nom original du fichier',
@@ -218,6 +219,7 @@ CREATE TABLE IF NOT EXISTS `proformas` (
   KEY `idx_upload_date` (`upload_date`),
   KEY `idx_status` (`status`),
   KEY `idx_upload_user` (`upload_user_id`),
+  KEY `idx_product` (`id_product`),
   -- Contrainte pour lier aux achats de matériaux
   CONSTRAINT `fk_proforma_achat` FOREIGN KEY (`achat_materiau_id`) 
     REFERENCES `achats_materiaux` (`id`) ON DELETE CASCADE ON UPDATE CASCADE


### PR DESCRIPTION
## Summary
- extend `proformas` table with `id_product` column and index
- allow uploading functions to store product id
- pass product id when available during proforma upload

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b71cfe0c832da732516bd0294f94