### PR TITLE
Handle product id for partial proforma uploads

### DIFF
--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -1334,7 +1334,8 @@ const SelectionManager = {
             quantity: checkbox.dataset.quantity || checkbox.getAttribute('data-quantity'),
             unit: checkbox.dataset.unit || checkbox.getAttribute('data-unit'),
             sourceTable: checkbox.dataset.sourceTable || checkbox.getAttribute('data-source-table') || 'expression_dym',
-            project: checkbox.dataset.project || checkbox.getAttribute('data-project') || ''
+            project: checkbox.dataset.project || checkbox.getAttribute('data-project') || '',
+            productId: checkbox.dataset.productId || checkbox.getAttribute('data-product-id') || ''
         };
     },
     /**
@@ -1750,6 +1751,7 @@ const ModalManager = {
                     <input type="hidden" name="material_ids[]" value="${material.id}">
                     <input type="hidden" name="source_table[${material.id}]" value="${material.sourceTable || 'expression_dym'}">
                     <input type="hidden" name="is_partial[${material.id}]" value="1">
+                    <input type="hidden" name="product_id[${material.id}]" value="${material.productId || ''}">
                 `;
         });
         // Initialiser l'autocomplétion des fournisseurs
@@ -2501,7 +2503,7 @@ const PartialOrdersManager = {
         // Vérifier la sélection
         const isChecked = selectedIds.includes(material.id?.toString()) ? 'checked' : '';
         return `
-        <tr class="${progress < 50 ? 'bg-yellow-50 pulse-animation' : ''}" data-id="${material.id}">
+        <tr class="${progress < 50 ? 'bg-yellow-50 pulse-animation' : ''}" data-id="${material.id}" data-product-id="${material.product_id || ''}">
             <td class="px-6 py-4 whitespace-nowrap">
                 <input type="checkbox" class="material-checkbox partial-material-checkbox"
                     data-id="${material.id}"
@@ -2509,6 +2511,7 @@ const PartialOrdersManager = {
                     data-designation="${Utils.escapeHtml(designation)}"
                     data-quantity="${restante}"
                     data-unit="${Utils.escapeHtml(unit)}"
+                    data-product-id="${material.product_id || ''}"
                     data-source-table="${sourceTable}"
                     ${isChecked}>
             </td>

--- a/User-Achat/commandes-traitement/api.php
+++ b/User-Achat/commandes-traitement/api.php
@@ -211,6 +211,7 @@ function handleGetRemainingMaterials($pdo)
                      ed.fournisseur,
                      ip.code_projet,
                      ip.nom_client,
+                     NULL as product_id,
                      'expression_dym' as source_table,
                      (
                          SELECT COALESCE(SUM(am.quantity), 0) 
@@ -237,6 +238,7 @@ function handleGetRemainingMaterials($pdo)
                      NULL as fournisseur,
                      CONCAT('SYS-', COALESCE(d.service_demandeur, 'Système')) as code_projet,
                      COALESCE(d.client, 'Demande interne') as nom_client,
+                     b.product_id,
                      'besoins' as source_table,
                      (
                          SELECT COALESCE(SUM(am.quantity), 0) 
@@ -861,6 +863,7 @@ function completeMultiplePartial($pdo, $user_id)
         $quantities = $_POST['quantities'] ?? [];
         $prices = $_POST['prices'] ?? [];
         $sourceTable = $_POST['source_table'] ?? [];
+        $productIds = $_POST['product_id'] ?? [];
         $createFournisseur = isset($_POST['create_fournisseur']) ? true : false;
 
         // Validation des données de base
@@ -940,6 +943,7 @@ function completeMultiplePartial($pdo, $user_id)
                 $quantiteCommande = floatval($quantities[$materialId] ?? 0);
                 $prixUnitaire = floatval($prices[$materialId] ?? 0);
                 $source = $sourceTable[$materialId] ?? 'expression_dym';
+                $productId = isset($productIds[$materialId]) && $productIds[$materialId] !== '' ? intval($productIds[$materialId]) : null;
 
                 if ($quantiteCommande <= 0 || $prixUnitaire <= 0) {
                     throw new Exception("Quantité ou prix invalide pour le matériau ID $materialId");
@@ -975,7 +979,8 @@ function completeMultiplePartial($pdo, $user_id)
                                 $_FILES['proforma_file'],
                                 $result['order_id'],
                                 $fournisseurId,
-                                $result['project_client'] ?? null
+                                $result['project_client'] ?? null,
+                                $productId
                             );
 
                             $proformaResults[] = [


### PR DESCRIPTION
## Summary
- expose `product_id` in partial materials API
- pass product data through selection to bulk completion
- store product id when uploading proforma for partial orders

## Testing
- `php -l User-Achat/commandes-traitement/api.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867c532ca84832d85dffabadcb4c204