### PR TITLE
Fix multiple proforma lines on bulk purchase

### DIFF
--- a/User-Achat/commandes-traitement/upload_proforma.php
+++ b/User-Achat/commandes-traitement/upload_proforma.php
@@ -121,6 +121,32 @@ class ProformaUploadHandler
     }
 
     /**
+     * Ajoute un enregistrement en base pour un fichier déjà uploadé
+     */
+    public function linkExistingFile($filename, $fileData, $achatMateriauxId, $fournisseurId, $projetClient = null, $productId = null)
+    {
+        // Pas de déplacement de fichier, on réutilise le fichier existant
+        $proformaId = $this->saveToDatabase(
+            $achatMateriauxId,
+            $fournisseurId,
+            $projetClient,
+            $filename,
+            $fileData,
+            $productId
+        );
+
+        // Journaliser comme duplication
+        $this->logUpload($proformaId, $achatMateriauxId, $filename, 'duplicate');
+
+        return [
+            'success' => true,
+            'proforma_id' => $proformaId,
+            'filename' => $filename,
+            'file_path' => 'uploads/proformas/' . $filename
+        ];
+    }
+
+    /**
      * Validation de base de l'upload
      */
     private function validateFileUpload($fileData)


### PR DESCRIPTION
## Summary
- support linking the same proforma file to multiple orders
- store uploaded proforma info once and reuse for subsequent lines

## Testing
- `php` not available -> linting skipped

------
https://chatgpt.com/codex/tasks/task_e_6867e4a21bc0832dab0f0b85ea7e5166