### PR TITLE
Add product images to partial orders view

### DIFF
--- a/User-Achat/achats_materiaux.php
+++ b/User-Achat/achats_materiaux.php
@@ -1846,6 +1846,7 @@ function formatNumber($number)
                                     </th>
                                     <th>Projet</th>
                                     <th>Client</th>
+                                    <th>Image</th>
                                     <th>Désignation</th>
                                     <th>Quantité initiale</th>
                                     <th>Quantité commandée</th>
@@ -1857,7 +1858,7 @@ function formatNumber($number)
                             <tbody id="partial-orders-body">
                                 <!-- Les données seront chargées dynamiquement par JavaScript -->
                                 <tr>
-                                    <td colspan="9" class="px-6 py-4 text-center text-sm text-gray-500">
+                                    <td colspan="10" class="px-6 py-4 text-center text-sm text-gray-500">
                                         Chargement des données...
                                     </td>
                                 </tr>

--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -844,6 +844,15 @@ const EventHandlers = {
                 }
             });
         }
+        const partialTable = document.getElementById('partialOrdersTable');
+        if (partialTable) {
+            partialTable.addEventListener('click', (e) => {
+                const target = e.target;
+                if (target.classList.contains('product-image')) {
+                    ModalManager.openImageViewer(target.getAttribute('src'), target.getAttribute('alt') || 'Aper\u00e7u');
+                }
+            });
+        }
     },
     setupModalEvents() {
         // Fermeture des modals
@@ -2409,7 +2418,7 @@ const PartialOrdersManager = {
         if (tbody) {
             tbody.innerHTML = `
             <tr>
-                <td colspan="9" class="px-6 py-4 text-center text-sm text-gray-500">
+                <td colspan="10" class="px-6 py-4 text-center text-sm text-gray-500">
                     <div class="flex items-center justify-center">
                         <svg class="animate-spin h-5 w-5 mr-3" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -2430,7 +2439,7 @@ const PartialOrdersManager = {
         if (tbody) {
             tbody.innerHTML = `
             <tr>
-                <td colspan="9" class="px-6 py-4 text-center text-sm text-red-500">
+                <td colspan="10" class="px-6 py-4 text-center text-sm text-red-500">
                     <div class="flex items-center justify-center">
                         <span class="material-icons mr-2">error_outline</span>
                         Erreur: ${message || 'Veuillez réessayer'}
@@ -2485,7 +2494,7 @@ const PartialOrdersManager = {
         if (!materials || materials.length === 0) {
             tbody.innerHTML = `
             <tr>
-                <td colspan="9" class="px-6 py-4 text-center text-sm text-gray-500">
+                <td colspan="10" class="px-6 py-4 text-center text-sm text-gray-500">
                     <div class="flex flex-col items-center">
                         <span class="material-icons text-4xl mb-2 text-gray-300">inventory_2</span>
                         <span>Aucune commande partielle trouvée.</span>
@@ -2531,6 +2540,9 @@ const PartialOrdersManager = {
         const expressionId = sourceTable === 'besoins' ?
             material.idExpression || material.idBesoin || '' :
             material.idExpression || '';
+        const imageHtml = material.product_image
+            ? `<img src="../${Utils.escapeHtml(material.product_image)}" alt="${Utils.escapeHtml(designation)}" class="product-image">`
+            : `<div class="product-image-placeholder"><span class="material-icons text-gray-400">inventory_2</span></div>`;
         // Calculer les valeurs
         const initialQty = parseFloat(material.quantite_initiale || material.initial_qt_acheter || 0);
         const orderedQty = parseFloat(material.quantite_commandee || material.quantite_deja_commandee || 0);
@@ -2556,6 +2568,7 @@ const PartialOrdersManager = {
             </td>
             <td class="px-6 py-4 whitespace-nowrap">${material.code_projet || '-'}</td>
             <td class="px-6 py-4 whitespace-nowrap">${material.nom_client || '-'}</td>
+            <td class="px-6 py-4 whitespace-nowrap">${imageHtml}</td>
             <td class="px-6 py-4 whitespace-nowrap font-medium">${Utils.escapeHtml(designation)}</td>
             <td class="px-6 py-4 whitespace-nowrap">${Utils.formatQuantity(initialQty)} ${Utils.escapeHtml(unit)}</td>
             <td class="px-6 py-4 whitespace-nowrap">${Utils.formatQuantity(orderedQty)} ${Utils.escapeHtml(unit)}</td>
@@ -2632,13 +2645,13 @@ const PartialOrdersManager = {
             buttons: CONFIG.DATATABLES.BUTTONS,
             columnDefs: [{
                 orderable: false,
-                targets: [0, 8]
+                targets: [0, 9]
             }, {
                 responsivePriority: 1,
-                targets: [3, 6]
+                targets: [4, 7]
             }],
             order: [
-                [4, 'desc']
+                [5, 'desc']
             ],
             pageLength: 10,
             drawCallback: () => {

--- a/User-Achat/commandes-traitement/api.php
+++ b/User-Achat/commandes-traitement/api.php
@@ -214,6 +214,7 @@ function handleGetRemainingMaterials($pdo)
                      ip.code_projet,
                      ip.nom_client,
                      NULL as product_id,
+                     p.product_image,
                      'expression_dym' as source_table,
                      (
                          SELECT COALESCE(SUM(am.quantity), 0) 
@@ -224,6 +225,7 @@ function handleGetRemainingMaterials($pdo)
                      ) as quantite_deja_commandee
                   FROM expression_dym ed
                   JOIN identification_projet ip ON ed.idExpression = ip.idExpression
+                  LEFT JOIN products p ON LOWER(p.product_name) = LOWER(ed.designation)
                   WHERE ed.qt_restante > 0 
                   AND ed.valide_achat = 'en_cours'";
 
@@ -241,6 +243,7 @@ function handleGetRemainingMaterials($pdo)
                      CONCAT('SYS-', COALESCE(d.service_demandeur, 'Système')) as code_projet,
                      COALESCE(d.client, 'Demande interne') as nom_client,
                      b.product_id,
+                     p.product_image,
                      'besoins' as source_table,
                      (
                          SELECT COALESCE(SUM(am.quantity), 0) 
@@ -251,6 +254,7 @@ function handleGetRemainingMaterials($pdo)
                      ) as quantite_deja_commandee
                   FROM besoins b
                   LEFT JOIN demandeur d ON b.idBesoin = d.idBesoin
+                  LEFT JOIN products p ON p.id = b.product_id
                   WHERE b.qt_demande > b.qt_acheter
                   AND b.achat_status = 'en_cours'";
 


### PR DESCRIPTION
## Summary
- include product image when fetching partial orders
- show product image column in "Matériaux à compléter" table
- render images in JS table rows and update DataTable configuration
- enable image viewer for the partial orders table

## Testing
- `php -l User-Achat/commandes-traitement/api.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68684b3bcda0832d972b93e66b1932ea