### PR TITLE
Ajout d'images produits dans les commandes en attente de réception

### DIFF
--- a/User-Achat/achats_materiaux.php
+++ b/User-Achat/achats_materiaux.php
@@ -2033,6 +2033,7 @@ function formatNumber($number)
                                             class="select-all-checkbox"></th>
                                     <th>Projet</th>
                                     <th>Client</th>
+                                    <th>Image</th>
                                     <th>Produit</th>
                                     <th>Quantité</th>
                                     <th>Unité</th>
@@ -2461,6 +2462,16 @@ function formatNumber($number)
                                                         <span class="text-gray-700">
                                                             <?= htmlspecialchars($material['nom_client'] ?? 'N/A') ?>
                                                         </span>
+                                                    </td>
+
+                                                    <td class="px-4 py-3">
+                                                        <?php if (!empty($material['product_image']) && file_exists('../' . ltrim($material['product_image'], '/'))): ?>
+                                                            <img src="../<?= htmlspecialchars($material['product_image']) ?>" alt="<?= htmlspecialchars($material['designation'] ?? 'Produit') ?>" class="product-image">
+                                                        <?php else: ?>
+                                                            <div class="product-image-placeholder">
+                                                                <span class="material-icons text-gray-400">inventory_2</span>
+                                                            </div>
+                                                        <?php endif; ?>
                                                     </td>
 
                                                     <td class="px-4 py-3">

--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -1071,15 +1071,15 @@ const DataTablesManager = {
             buttons: CONFIG.DATATABLES.BUTTONS,
             columnDefs: [{
                 orderable: false,
-                targets: [0, 11]
+                targets: [0, 12]
             },
             {
                 type: 'date-fr',
-                targets: 9
+                targets: 10
             },
             {
                 type: 'num',
-                targets: 10
+                targets: 11
             }
             ],
             order: [

--- a/User-Achat/assets/js/ordered-materials-filters.js
+++ b/User-Achat/assets/js/ordered-materials-filters.js
@@ -505,15 +505,15 @@ const OrderedMaterialsFilters = {
         }
 
         if (this.filters.produit) {
-            this.dataTable.column(3).search(this.filters.produit, true, false);
+            this.dataTable.column(4).search(this.filters.produit, true, false);
         }
 
         if (this.filters.unite) {
-            this.dataTable.column(5).search(this.escapeRegex(this.filters.unite), true, false);
+            this.dataTable.column(6).search(this.escapeRegex(this.filters.unite), true, false);
         }
 
         if (this.filters.fournisseur) {
-            this.dataTable.column(8).search(this.escapeRegex(this.filters.fournisseur), true, false);
+            this.dataTable.column(9).search(this.escapeRegex(this.filters.fournisseur), true, false);
         }
 
         // Appliquer les filtres personnalisés (date, prix, validation)
@@ -552,7 +552,7 @@ const OrderedMaterialsFilters = {
 
             // Filtre de date
             if (this.filters.dateDebut || this.filters.dateFin) {
-                const dateStr = data[9]; // Colonne Date
+                const dateStr = data[10]; // Colonne Date
                 if (!dateStr) return false;
 
                 try {
@@ -584,7 +584,7 @@ const OrderedMaterialsFilters = {
 
             // Filtre de prix
             if (this.filters.prixMin || this.filters.prixMax) {
-                const priceStr = data[7]; // Colonne Prix unitaire
+                const priceStr = data[8]; // Colonne Prix unitaire
                 if (!priceStr) return false;
 
                 try {
@@ -609,7 +609,7 @@ const OrderedMaterialsFilters = {
 
             // Filtre statut de validation basé sur les statuts spécifiques
             if (this.filters.validation) {
-                const statusColumn = data[6]; // Colonne Statut
+                const statusColumn = data[7]; // Colonne Statut
 
                 // Créer un élément temporaire pour extraire le texte du statut sans HTML
                 const tempDiv = document.createElement('div');


### PR DESCRIPTION
## Summary
- affiche la colonne **Image** dans la section "Matériaux en attente de réception"
- rend les images dans les lignes du tableau
- ajuste la configuration DataTables pour la nouvelle colonne
- met à jour les filtres JS pour correspondre aux nouveaux index

## Testing
- `node --check User-Achat/assets/js/ordered-materials-filters.js`
- `node --check User-Achat/assets/js/achats-materiaux.js`
- `php -l User-Achat/achats_materiaux.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868510559bc832d8b5b2ddc9b09eda2