### PR TITLE
Add product images for received materials

### DIFF
--- a/User-Achat/achats_materiaux.php
+++ b/User-Achat/achats_materiaux.php
@@ -377,7 +377,7 @@ try {
     // Récupérer les matériaux reçus avec informations d'achat
     $recentsQuery = "
     -- Requête pour les matériaux de expression_dym
-    SELECT 
+    SELECT
         ed.id as ed_id,
         ed.idExpression,
         ed.designation,
@@ -393,6 +393,7 @@ try {
         ip.code_projet,
         ip.nom_client,
         u.name as acheteur_name,
+        p.product_image,
         (
             SELECT MAX(id) 
             FROM achats_materiaux 
@@ -416,6 +417,7 @@ try {
     FROM expression_dym ed
     LEFT JOIN identification_projet ip ON ed.idExpression = ip.idExpression
     LEFT JOIN users_exp u ON ed.user_achat = u.id
+    LEFT JOIN products p ON LOWER(p.product_name) = LOWER(ed.designation)
     WHERE ed.valide_achat = 'reçu'";
 
     // Ajouter la condition de date si la fonction existe
@@ -449,6 +451,7 @@ try {
             AND am.designation = b.designation_article
         ) as fournisseur,
         b.achat_status as valide_achat,
+        p.product_image,
         b.created_at,
         b.updated_at,
         'SYS' as code_projet,
@@ -480,6 +483,7 @@ try {
         'besoins' as source_table
     FROM besoins b
     LEFT JOIN demandeur d ON b.idBesoin = d.idBesoin
+    LEFT JOIN products p ON p.id = b.product_id
     WHERE b.achat_status = 'reçu'";
 
     // Ajouter la condition de date si la fonction existe
@@ -1793,7 +1797,7 @@ function formatNumber($number)
                                             error_log("Erreur de traitement du matériau : " . $materialException->getMessage());
                                         ?>
                                             <tr class="bg-red-100">
-                                                <td colspan="11">Erreur de chargement du matériau</td>
+                                                <td colspan="12">Erreur de chargement du matériau</td>
                                             </tr>
                                     <?php
                                         }
@@ -2623,6 +2627,7 @@ function formatNumber($number)
                                 <tr>
                                     <th>Projet</th>
                                     <th>Client</th>
+                                    <th>Image</th>
                                     <th>Produit</th>
                                     <th>Quantité</th>
                                     <th>Unité</th>
@@ -2672,6 +2677,15 @@ function formatNumber($number)
                                             <tr class="material-row received">
                                                 <td><?= $projet ?></td>
                                                 <td><?= $client ?></td>
+                                                <td>
+                                                    <?php if (!empty($material['product_image']) && file_exists('../' . ltrim($material['product_image'], '/'))): ?>
+                                                        <img src="../<?= htmlspecialchars($material['product_image']) ?>" alt="<?= htmlspecialchars($designation) ?>" class="product-image">
+                                                    <?php else: ?>
+                                                        <div class="product-image-placeholder">
+                                                            <span class="material-icons text-gray-400">inventory_2</span>
+                                                        </div>
+                                                    <?php endif; ?>
+                                                </td>
                                                 <td><?= $designation ?><?= $sourceIndicator ?></td>
                                                 <td><?= number_format(floatval($quantite), 2, ',', ' ') ?></td>
                                                 <td><?= $unite ?></td>

--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -809,6 +809,15 @@ const EventHandlers = {
                 ButtonStateManager.updateAllButtons();
             });
         }
+        const recentsTable = document.getElementById('recentPurchasesTable');
+        if (recentsTable) {
+            recentsTable.addEventListener('click', (e) => {
+                const target = e.target;
+                if (target.classList.contains('product-image')) {
+                    ModalManager.openImageViewer(target.getAttribute('src'), target.getAttribute('alt') || 'Aper\u00e7u');
+                }
+            });
+        }
         // Case à cocher "Tout sélectionner" pour les matériaux commandés
         const selectAllOrdered = document.getElementById('select-all-ordered-materials');
         if (selectAllOrdered) {
@@ -1117,14 +1126,14 @@ const DataTablesManager = {
             buttons: CONFIG.DATATABLES.BUTTONS,
             columnDefs: [{
                 type: 'date-fr',
-                targets: 8
+                targets: 9
             },
             {
-                targets: 9,
+                targets: 10,
                 render: (data, type, row) => {
-                    const expressionId = row[10] || '';
-                    const orderId = row[11] || '';
-                    let designation = row[2] || '';
+                    const expressionId = row[11] || '';
+                    const orderId = row[12] || '';
+                    let designation = row[3] || '';
                     designation = designation.replace(/<[^>]*>/g, '');
                     const cleanDesignation = Utils.escapeString(designation);
                     return `
@@ -1148,7 +1157,7 @@ const DataTablesManager = {
             }
             ],
             order: [
-                [8, 'desc']
+                [9, 'desc']
             ],
             pageLength: CONFIG.DATATABLES.PAGE_LENGTH
         });


### PR DESCRIPTION
## Summary
- include product images in materials received query
- show image column in received materials table
- handle image clicks for recent purchases
- adjust DataTables indexes for new column

## Testing
- `node -v`
- `php -l User-Achat/achats_materiaux.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686854afde70832d8184e1d7d0d68f14