### PR TITLE
Add product images to canceled orders

### DIFF
--- a/User-Achat/achats_materiaux.php
+++ b/User-Achat/achats_materiaux.php
@@ -2802,6 +2802,7 @@ function formatNumber($number)
                             <tr>
                                 <th>Projet</th>
                                 <th>Client</th>
+                                <th>Image</th>
                                 <th>Produit</th>
                                 <th>Statut original</th>
                                 <th>Quantité</th>
@@ -2814,7 +2815,7 @@ function formatNumber($number)
                         <tbody>
                             <!-- Les données seront chargées dynamiquement -->
                             <tr>
-                                <td colspan="9" class="text-center py-4">Chargement des données...</td>
+                                <td colspan="10" class="text-center py-4">Chargement des données...</td>
                             </tr>
                         </tbody>
                     </table>

--- a/User-Achat/api_canceled/api_getCanceledOrders.php
+++ b/User-Achat/api_canceled/api_getCanceledOrders.php
@@ -55,6 +55,7 @@ try {
         COALESCE(ed.unit, b.caracteristique, CASE WHEN co.order_id = 0 THEN NULL ELSE am.unit END) as unit,
         COALESCE(ed.prix_unitaire, CASE WHEN co.order_id = 0 THEN NULL ELSE am.prix_unitaire END) as prix_unitaire,
         COALESCE(ed.fournisseur, CASE WHEN co.order_id = 0 THEN NULL ELSE am.fournisseur END) as fournisseur,
+        p.product_image,
         /* Récupérer les infos pour les besoins système */
         d.client as demandeur_nom,
         d.service_demandeur,
@@ -93,6 +94,8 @@ try {
     LEFT JOIN besoins b ON (co.project_id = b.idBesoin AND LOWER(co.designation) = LOWER(b.designation_article))
     /* Jointure avec demandeur pour les infos sur les besoins système */
     LEFT JOIN demandeur d ON b.idBesoin = d.idBesoin
+    /* Récupérer l'image du produit */
+    LEFT JOIN products p ON LOWER(p.product_name) = LOWER(co.designation)
     ORDER BY co.canceled_at DESC";
 
     $stmt = $pdo->prepare($query);
@@ -210,6 +213,7 @@ try {
             'original_status' => $formattedStatus,
             'quantity' => $formattedQuantity,
             'fournisseur' => $order['fournisseur'] ?: 'Non spécifié',
+            'product_image' => $order['product_image'],
             'canceled_at' => $canceledAt,
             'cancel_reason' => $order['cancel_reason'],
             'order_id' => $order['order_id'],

--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -1264,6 +1264,16 @@ const DataTablesManager = {
                 data: 'nom_client'
             },
             {
+                data: 'product_image',
+                render: (data, type, row) => {
+                    if (data) {
+                        return `<img src="../${Utils.escapeHtml(data)}" alt="${Utils.escapeHtml(row.designation)}" class="product-image">`;
+                    }
+                    return `<span class="material-icons text-gray-400">inventory_2</span>`;
+                },
+                orderable: false
+            },
+            {
                 data: 'designation'
             },
             {
@@ -1294,10 +1304,10 @@ const DataTablesManager = {
             ],
             columnDefs: [{
                 type: 'date-fr',
-                targets: 6
+                targets: 7
             }],
             order: [
-                [6, 'desc']
+                [7, 'desc']
             ],
             pageLength: CONFIG.DATATABLES.PAGE_LENGTH
         });


### PR DESCRIPTION
## Summary
- show product images in the canceled orders table
- include product_image in API response
- display product images in DataTable

## Testing
- `php -l User-Achat/api_canceled/api_getCanceledOrders.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68685786a560832d803f1d70a7955f73