### PR TITLE
Add proforma view button

### DIFF
--- a/User-Achat/achats_materiaux.php
+++ b/User-Achat/achats_materiaux.php
@@ -2104,12 +2104,23 @@ function formatNumber($number)
                                                 OR JSON_CONTAINS(po.related_expressions, CONCAT('\"', main_data.expression_id, '\"')))
                                          ORDER BY po.generated_at DESC LIMIT 1) as user_finance_id,
                                                                 
-                                        (SELECT po.file_path 
-                                         FROM purchase_orders po 
+                                        (SELECT po.file_path
+                                         FROM purchase_orders po
                                          WHERE (BINARY po.expression_id = BINARY main_data.expression_id
                                                 OR JSON_CONTAINS(po.related_expressions, CONCAT('\"', main_data.expression_id, '\"')))
-                                         ORDER BY po.generated_at DESC LIMIT 1) as bon_commande_path
-                                                                
+                                         ORDER BY po.generated_at DESC LIMIT 1) as bon_commande_path,
+
+                                        (SELECT pr.file_path
+                                         FROM proformas pr
+                                         WHERE pr.achat_materiau_id = (
+                                             SELECT am.id
+                                             FROM achats_materiaux am
+                                             WHERE BINARY am.expression_id = BINARY main_data.expression_id
+                                             AND BINARY am.designation = BINARY main_data.designation
+                                             ORDER BY am.date_achat DESC LIMIT 1
+                                         )
+                                         ORDER BY pr.upload_date DESC LIMIT 1) as proforma_path
+
                                     FROM (
                                         /* SOUS-REQUÊTE 1: Matériaux depuis expression_dym */
                                         SELECT 
@@ -2548,6 +2559,20 @@ function formatNumber($number)
                                                                     </a>
                                                                 <?php
                                                                 }
+                                                            }
+
+                                                            // Bouton pour voir le pro-forma associé
+                                                            if (!empty($material['proforma_path'])) {
+                                                                $proformaPath = $material['proforma_path'];
+                                                                if (strpos($proformaPath, 'uploads/proformas/') !== 0) {
+                                                                    $proformaPath = 'uploads/proformas/' . ltrim($proformaPath, '/');
+                                                                }
+                                                                $proformaUrl = '../' . $proformaPath;
+                                                            ?>
+                                                                <a href="<?= htmlspecialchars($proformaUrl) ?>" class="btn-action text-purple-600 hover:text-purple-800 mr-2" title="Voir le pro-forma" target="_blank">
+                                                                    <span class="material-icons">visibility</span>
+                                                                </a>
+                                                            <?php
                                                             }
 
                                                             // Bouton Modifier (Super Admin uniquement)

--- a/User-Achat/gestion-bon-commande/api/api_get_stored_orders.php
+++ b/User-Achat/gestion-bon-commande/api/api_get_stored_orders.php
@@ -45,17 +45,23 @@ function formatAmountSafely($amount) {
 
 try {
     // MISE À JOUR : Récupérer tous les bons de commande avec gestion des rejets
-    $query = "SELECT 
-                po.id, 
-                po.order_number, 
+    $query = "SELECT
+                po.id,
+                po.order_number,
                 po.download_reference,
-                po.expression_id, 
+                po.expression_id,
                 po.related_expressions,
-                po.file_path, 
-                po.fournisseur, 
-                po.montant_total, 
-                po.user_id, 
-                po.is_multi_project, 
+                po.file_path,
+                -- Chemin du dernier pro-forma lié à ce bon de commande
+                (SELECT pr.file_path
+                 FROM proformas pr
+                 WHERE pr.bon_commande_id = po.id
+                 ORDER BY pr.upload_date DESC
+                 LIMIT 1) AS proforma_path,
+                po.fournisseur,
+                po.montant_total,
+                po.user_id,
+                po.is_multi_project,
                 po.generated_at,
                 po.signature_finance,
                 po.user_finance_id,
@@ -66,9 +72,9 @@ try {
                 u.name as username,
                 uf.name as finance_username,
                 ur.name as rejected_by_username,
-                CASE 
-                    WHEN po.expression_id LIKE '%EXP_B%' THEN 'besoins' 
-                    ELSE 'expression_dym' 
+                CASE
+                    WHEN po.expression_id LIKE '%EXP_B%' THEN 'besoins'
+                    ELSE 'expression_dym'
                 END as source_table
               FROM purchase_orders po
               LEFT JOIN users_exp u ON po.user_id = u.id
@@ -164,6 +170,7 @@ try {
                 'expression_id' => $order['expression_id'] ?? '',
                 'related_expressions' => $order['related_expressions'],
                 'file_path' => $order['file_path'] ?? '',
+                'proforma_path' => $order['proforma_path'] ?? null,
                 'fournisseur' => $order['fournisseur'] ?? 'N/A',
                 'montant_total' => $amountData['formatted'],
                 'montant_total_raw' => $amountData['raw'],
@@ -199,6 +206,7 @@ try {
                 'expression_id' => '',
                 'related_expressions' => null,
                 'file_path' => '',
+                'proforma_path' => null,
                 'fournisseur' => 'Erreur',
                 'montant_total' => '0 FCFA',
                 'montant_total_raw' => 0,

--- a/User-Achat/gestion-bon-commande/api/search/search_by_product.php
+++ b/User-Achat/gestion-bon-commande/api/search/search_by_product.php
@@ -108,6 +108,11 @@ try {
             po.expression_id,
             po.related_expressions,
             po.file_path,
+            (SELECT pr.file_path
+             FROM proformas pr
+             WHERE pr.bon_commande_id = po.id
+             ORDER BY pr.upload_date DESC
+             LIMIT 1) AS proforma_path,
             po.fournisseur,
             po.montant_total,
             po.user_id,
@@ -222,6 +227,7 @@ try {
             'signature_finance' => $row['signature_finance'],
             'user_finance_id' => $row['user_finance_id'],
             'file_path' => $row['file_path'],
+            'proforma_path' => $row['proforma_path'],
             'product_found' => $row['product_found'],
             'product_quantity' => $row['product_quantity'],
             'product_unit' => $row['product_unit'],

--- a/User-Achat/gestion-bon-commande/commandes_archive.php
+++ b/User-Achat/gestion-bon-commande/commandes_archive.php
@@ -1340,13 +1340,20 @@ if ($action === 'delete' && isset($_GET['id'])) {
 
                         // NOUVEAU : Bouton pour voir les détails de rejet
                         const rejectionBtn = isRejected ?
-                            `<button onclick="Modal.showRejectionDetails(${orderId})" 
+                            `<button onclick="Modal.showRejectionDetails(${orderId})"
                class="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded text-sm"
                title="Détails du rejet">
                <i class="material-icons mr-1" style="font-size: 14px;">error</i>Rejet
             </button>` : '';
 
-                        return `<div class="flex space-x-2">${viewBtn}${downloadBtn}${validatedBtn}${rejectionBtn}</div>`;
+                        const proformaBtn = row.proforma_path ?
+                            `<a href="../../${row.proforma_path.startsWith('uploads/proformas/') ? row.proforma_path : 'uploads/proformas/' + row.proforma_path.replace(/^\/+/, '')}"
+               class="bg-indigo-500 hover:bg-indigo-600 text-white px-3 py-1 rounded text-sm inline-block"
+               title="Voir pro-forma" target="_blank">
+               <i class="material-icons mr-1" style="font-size: 14px;">visibility</i>Pro-forma
+            </a>` : '';
+
+                        return `<div class="flex space-x-2">${viewBtn}${downloadBtn}${validatedBtn}${rejectionBtn}${proformaBtn}</div>`;
                     },
                     orderable: false
                 }
@@ -1637,6 +1644,7 @@ if ($action === 'delete' && isset($_GET['id'])) {
                     user_finance_id: result.user_finance_id,
                     finance_username: result.finance_username || null,
                     file_path: result.file_path,
+                    proforma_path: result.proforma_path,
                     // NOUVEAU : Données de rejet
                     status: result.status || 'pending',
                     rejected_at: result.rejected_at,


### PR DESCRIPTION
## Summary
- include proforma path when listing purchase orders
- expose proforma path in product search API
- show a button to view linked pro-forma in the orders archive

## Testing
- `php` was not available so syntax could not be checked

------
https://chatgpt.com/codex/tasks/task_e_686b7c27b30c832db98729073c49e0d5