### PR TITLE
Add product images in canceled orders table

### DIFF
--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -1264,6 +1264,16 @@ const DataTablesManager = {
                 data: 'nom_client'
             },
             {
+                data: 'product_image',
+                render: (data, type, row) => {
+                    const src = data ? `../${Utils.escapeHtml(data)}` : null;
+                    const alt = Utils.escapeHtml(row.designation || 'Produit');
+                    return src ? `<img src="${src}" alt="${alt}" class="product-image">` :
+                        `<div class="product-image-placeholder"><span class="material-icons text-gray-400">inventory_2</span></div>`;
+                },
+                orderable: false
+            },
+            {
                 data: 'designation'
             },
             {
@@ -1294,10 +1304,10 @@ const DataTablesManager = {
             ],
             columnDefs: [{
                 type: 'date-fr',
-                targets: 6
+                targets: 7
             }],
             order: [
-                [6, 'desc']
+                [7, 'desc']
             ],
             pageLength: CONFIG.DATATABLES.PAGE_LENGTH
         });


### PR DESCRIPTION
## Summary
- include product_image info in `api_getCanceledOrders.php`
- add a new column in the canceled orders DataTable for product images

## Testing
- `node -v`
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b8d852f24832db2ac2b19ef2c1bd6