### PR TITLE
Fix default ordering for ordered materials

### DIFF
--- a/User-Achat/assets/js/achats-materiaux.js
+++ b/User-Achat/assets/js/achats-materiaux.js
@@ -1112,7 +1112,7 @@ const DataTablesManager = {
             }
             ],
             order: [
-                [9, 'desc']
+                [10, 'desc']
             ],
             pageLength: CONFIG.DATATABLES.PAGE_LENGTH,
             drawCallback: () => {

--- a/User-Achat/test/achats_materiaux.php
+++ b/User-Achat/test/achats_materiaux.php
@@ -4260,7 +4260,7 @@ function formatNumber($number)
                         }
                     ],
                     order: [
-                        [9, 'desc']
+                        [10, 'desc']
                     ],
                     pageLength: CONFIG.DATATABLES.PAGE_LENGTH,
                     drawCallback: () => {

--- a/User-Achat/test/script_complet.bak.txt
+++ b/User-Achat/test/script_complet.bak.txt
@@ -1029,7 +1029,7 @@
                     }
                 ],
                 order: [
-                    [9, 'desc']
+                    [10, 'desc']
                 ],
                 pageLength: CONFIG.DATATABLES.PAGE_LENGTH,
                 drawCallback: () => {


### PR DESCRIPTION
## Summary
- update ordered materials datatable to sort by date (descending)
- keep test scripts consistent with new ordering

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b993cd400832d9d80a9954fe14bdb