### PR TITLE
Display payment method in finance order details

### DIFF
--- a/User-Finance/assets/js/ModalManager.js
+++ b/User-Finance/assets/js/ModalManager.js
@@ -883,7 +883,7 @@ class ModalManager {
                         </div>
                         <div class="space-y-2">
                             <p><strong class="text-gray-700">Montant:</strong> <span class="text-red-600 font-bold text-lg">${this.formatAmount(order.montant_total)} FCFA</span></p>
-                            <p><strong class="text-gray-700">Mode de paiement:</strong> <span class="text-gray-900">${validationDetails.modePaiement || 'Non spécifié'}</span></p>
+                            <p><strong class="text-gray-700">Mode de paiement:</strong> <span class="text-gray-900">${order.mode_paiement || validationDetails.modePaiement || 'Non spécifié'}</span></p>
                             <p><strong class="text-gray-700">Créé par:</strong> <span class="text-gray-900">${order.username_creation || validationDetails.validated_by_name || 'Non renseigné'}</span></p>
                         </div>
                     </div>
@@ -991,7 +991,7 @@ class ModalManager {
                         </div>
                         <div class="space-y-2">
                             <p><strong class="text-gray-700">Montant:</strong> <span class="text-green-600 font-bold text-lg">${this.formatAmount(order.montant_total)} FCFA</span></p>
-                            <p><strong class="text-gray-700">Mode de paiement:</strong> <span class="text-gray-900">${validationDetails.modePaiement || 'Non spécifié'}</span></p>
+                            <p><strong class="text-gray-700">Mode de paiement:</strong> <span class="text-gray-900">${order.mode_paiement || validationDetails.modePaiement || 'Non spécifié'}</span></p>
                             <p><strong class="text-gray-700">Validé par:</strong> <span class="text-gray-900">${order.username_creation || validationDetails.validated_by_name || 'Non renseigné'}</span></p>
                         </div>
                     </div>
@@ -1289,7 +1289,7 @@ class ModalManager {
                     <span class="material-icons mr-2">credit_card</span>
                     MODE DE PAIEMENT
                 </h3>
-                <p class="font-medium text-lg ${isRejected ? 'text-red-600' : ''}">${validationDetails.modePaiement || 'Non spécifié'}</p>
+                <p class="font-medium text-lg ${isRejected ? 'text-red-600' : ''}">${order.mode_paiement || validationDetails.modePaiement || 'Non spécifié'}</p>
                 ${isRejected ? `<p class="text-sm text-red-600 mt-1">Mode de paiement annulé suite au rejet</p>` : ''}
             </div>
             

--- a/User-Finance/classes/PurchaseOrderService.php
+++ b/User-Finance/classes/PurchaseOrderService.php
@@ -107,15 +107,17 @@ class PurchaseOrderService
     public function getOrderFullDetails(int $orderId): ?array
     {
         // Récupérer les informations principales du bon avec les données de rejet
-        $orderQuery = "SELECT 
+        $orderQuery = "SELECT
                     po.*,
                     u.name as username_creation,
                     uf.name as finance_username,
-                    ur.name as rejected_by_username
+                    ur.name as rejected_by_username,
+                    pm.label AS mode_paiement
                   FROM purchase_orders po
                   LEFT JOIN users_exp u ON po.user_id = u.id
                   LEFT JOIN users_exp uf ON po.user_finance_id = uf.id
                   LEFT JOIN users_exp ur ON po.rejected_by_user_id = ur.id
+                  LEFT JOIN payment_methods pm ON po.mode_paiement_id = pm.id
                   WHERE po.id = ?";
 
         try {


### PR DESCRIPTION
## Summary
- join payment_methods table when retrieving order details
- show payment method label in order detail modals

## Testing
- `php -l User-Finance/classes/PurchaseOrderService.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce1c53a88832db634f6483459776c