### PR TITLE
Improve pending filters design

### DIFF
--- a/User-Finance/assets/css/finance-dashboard.css
+++ b/User-Finance/assets/css/finance-dashboard.css
@@ -942,15 +942,27 @@ main {
    ================================================================ */
 #pending-filters {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-    gap: var(--spacing-sm);
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: var(--spacing-md);
     margin-bottom: var(--spacing-md);
+    padding: var(--spacing-md);
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-sm);
+}
+
+#pending-filters > div,
+.filter-field {
+    display: flex;
+    flex-direction: column;
 }
 
 #pending-filters label {
     font-size: 0.75rem;
-    font-weight: 500;
+    font-weight: 600;
     color: var(--text-secondary);
+    margin-bottom: 0.25rem;
 }
 
 #pending-filters input,
@@ -959,7 +971,16 @@ main {
     padding: 0.5rem 0.75rem;
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
+    background: var(--bg-secondary);
     font-size: 0.875rem;
+    transition: var(--transition-fast);
+}
+
+#pending-filters input:focus,
+#pending-filters select:focus {
+    outline: none;
+    border-color: var(--finance-primary);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
 }
 
 #pending-filters button {

--- a/User-Finance/dashboard.php
+++ b/User-Finance/dashboard.php
@@ -199,27 +199,27 @@ $pageConfig = [
 
                         <!-- Filtres avancés -->
                         <div id="pending-filters" class="mb-4">
-                            <div>
+                            <div class="filter-field">
                                 <label for="filter-date-from">Date début</label>
                                 <input type="date" id="filter-date-from">
                             </div>
-                            <div>
+                            <div class="filter-field">
                                 <label for="filter-date-to">Date fin</label>
                                 <input type="date" id="filter-date-to">
                             </div>
-                            <div>
+                            <div class="filter-field">
                                 <label for="filter-fournisseur">Fournisseur</label>
                                 <input type="text" id="filter-fournisseur" placeholder="Nom fournisseur">
                             </div>
-                            <div>
+                            <div class="filter-field">
                                 <label for="filter-payment">Mode de paiement</label>
                                 <select id="filter-payment"></select>
                             </div>
-                            <div>
+                            <div class="filter-field">
                                 <label for="filter-min-amount">Montant min</label>
                                 <input type="number" id="filter-min-amount" placeholder="0">
                             </div>
-                            <div>
+                            <div class="filter-field">
                                 <label for="filter-max-amount">Montant max</label>
                                 <input type="number" id="filter-max-amount" placeholder="0">
                             </div>


### PR DESCRIPTION
## Summary
- modernize look of Finance dashboard filter section
- style filter layout with a card-like appearance

## Testing
- `php -l User-Finance/dashboard.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ced4f8854832d929b8bed012e4d9b