### PR TITLE
Add toggle to show/hide finance filters

### DIFF
--- a/User-Finance/assets/css/finance-dashboard.css
+++ b/User-Finance/assets/css/finance-dashboard.css
@@ -353,6 +353,18 @@ body.modal-open {
     transform: translateY(-1px);
 }
 
+/* Bouton affichage filtres */
+.btn-toggle-filters {
+    background: linear-gradient(135deg, #f8fafc, #eef2f7);
+    color: var(--finance-primary);
+    border-color: var(--finance-primary);
+}
+
+.btn-toggle-filters:hover {
+    background: linear-gradient(135deg, #eef2f7, #e2e8f0);
+    transform: translateY(-1px);
+}
+
 /* ================================================================
    CONTAINER PRINCIPAL
    ================================================================ */

--- a/User-Finance/dashboard.php
+++ b/User-Finance/dashboard.php
@@ -197,6 +197,14 @@ $pageConfig = [
                             <p class="table-subtitle">Cliquez sur "Signer" pour valider un bon de commande</p>
                         </div>
 
+                        <!-- Bouton pour afficher/masquer les filtres -->
+                        <div class="mb-2 text-right">
+                            <button id="toggle-pending-filters" type="button" class="action-btn btn-toggle-filters">
+                                <span class="material-icons text-sm">filter_alt_off</span>
+                                Masquer les filtres
+                            </button>
+                        </div>
+
                         <!-- Filtres avancés -->
                         <div id="pending-filters" class="mb-4">
                             <div class="filter-field">
@@ -473,6 +481,15 @@ $pageConfig = [
                     } finally {
                         $(this).prop('disabled', false).html('<span class="material-icons mr-2">refresh</span>Actualiser');
                     }
+                });
+
+                // Afficher ou masquer les filtres avancés
+                $('#toggle-pending-filters').on('click', function() {
+                    const filters = $('#pending-filters');
+                    filters.toggleClass('hidden');
+                    const hidden = filters.hasClass('hidden');
+                    const icon = hidden ? 'filter_alt' : 'filter_alt_off';
+                    $(this).html(`<span class="material-icons text-sm">${icon}</span> ${hidden ? 'Afficher les filtres' : 'Masquer les filtres'}`);
                 });
 
                 // Raccourcis clavier


### PR DESCRIPTION
## Summary
- add a button to collapse/expand the pending filters in Finance dashboard
- create styles for the toggle button
- enable JS logic to change button text and hide/show the filter section

## Testing
- `php -l User-Finance/dashboard.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cf064aea0832d8e8e97c09669bcba